### PR TITLE
Fix MySQLController.addNewPost and update setup.sql

### DIFF
--- a/setup.sql
+++ b/setup.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Host: localhost:8889
--- Generation Time: Oct 24, 2021 at 01:26 AM
+-- Generation Time: Nov 10, 2021 at 10:15 PM
 -- Server version: 5.7.34
 -- PHP Version: 7.4.21
 
@@ -116,7 +116,8 @@ CREATE TABLE `recipes` (
 --
 
 INSERT INTO `recipes` (`recipe_id`, `title`) VALUES
-    ('z', 'Amazing recipe');
+                                                 ('z', 'My new recipe title!2021-11-10T17:07:36.676543'),
+                                                 ('x', 'italian recipe');
 
 -- --------------------------------------------------------
 
@@ -135,7 +136,9 @@ CREATE TABLE `recipes_steps` (
 --
 
 INSERT INTO `recipes_steps` (`recipe_id`, `step_number`, `step_text`) VALUES
-    ('z', 1, 'The first step is to make the dish.');
+                                                                          ('x', 1, 'Just make the italian recipe!'),
+                                                                          ('z', 0, 'The first step is to make the dish.'),
+                                                                          ('z', 1, 'The second step is to finish making the dish.');
 
 -- --------------------------------------------------------
 
@@ -156,8 +159,8 @@ CREATE TABLE `recipe_ingredients` (
 --
 
 INSERT INTO `recipe_ingredients` (`recipe_id`, `ingredient_name`, `ingredient_count`, `ingredient_amount`, `ingredient_measurement`) VALUES
-                                                                                                                                         ('z', 'awesome sauce', NULL, 5, 'tbsp'),
-                                                                                                                                         ('z', 'apple', 20000, NULL, NULL);
+                                                                                                                                         ('z', 'apple', 20000, NULL, NULL),
+                                                                                                                                         ('z', 'awesome sauce', NULL, 5, 'tbsp');
 
 -- --------------------------------------------------------
 

--- a/src/main/java/controllers/MySQLController.java
+++ b/src/main/java/controllers/MySQLController.java
@@ -423,7 +423,7 @@ public class MySQLController extends DatabaseManager {
 
             PreparedStatement preparedStmt = connection.prepareStatement(query);
             preparedStmt.setString(1, recipe.getId());
-            preparedStmt.setString(2, post.getId());
+            preparedStmt.setString(2, recipe.getTitle());
 
             preparedStmt.execute();
         } catch (Exception e) {


### PR DESCRIPTION
Fixed a bug in addNewPost where we were saving the post ID as the recipe title.

Also updated setup.sql so there is a recipe with id 'x'. Previously there was a Post saved in the Database referencing a recipe with id 'x', but the recipe did not exist, which caused an error.